### PR TITLE
升级jcore-react-native和jpush-react-native, 移除iOS剪切板功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "license": "ISC",
   "author": "wicked.tc130",
-  "version": "2.7.5",
+  "version": "2.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/helloworld-Andrew/jpush-react-native"
@@ -16,7 +16,7 @@
     "JPush"
   ],
   "peerDependencies": {
-    "jcore-react-native": ">= 1.5.0",
+    "jcore-react-native": ">= 1.9.0",
     "react-native": ">= 0.50"
   }
 }


### PR DESCRIPTION
旧版的SDK会调用[UIPasteboard generalPasteboard], 弹出如图提示，影响用户体验。新版SDK移除了iOS剪切板功能， 不会再有提示。
![IMG_41A237C625AD-1](https://user-images.githubusercontent.com/3918091/98350184-f46c9d80-2055-11eb-883d-9884a311ac3e.jpeg)
